### PR TITLE
Support SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ Example:
     clone-certificate: 90051
 ```
 
+### Databases
+
+This action creates a new database for each preview site and deletes the database when the preview site is deleted. If your Forge server has one of the default supported database engines installed (MySQL, MariaDB, or PostgreSQL), that database engine will be used and no additional configuration is necessary.
+
+To use SQLite, set your preview sites’ `DB_CONNECTION` environment variable to `sqlite` using [the `environment` input](#environment):
+
+```yaml
+- uses: bakerkretzmar/laravel-deploy-preview@v2
+  with:
+    forge-token: ${{ secrets.FORGE_TOKEN }}
+    servers: |
+      qa-1.acme.dev 60041
+    environment: |
+      DB_CONNECTION=sqlite
+```
+
 ## Development
 
 This action is loosely based on GitHub's [hello-world-javascript-action](https://github.com/actions/hello-world-javascript-action) and [typescript-action](https://github.com/actions/typescript-action) templates. It's written in TypeScript and compiled with [`ncc`](https://github.com/vercel/ncc) into a single JavaScript file.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "ncc build src/index.ts --source-map --license licenses.txt",
     "debug": "ncc run src/debug.ts",
     "test": "vitest unit",
-    "test:integration": "vitest run integration --test-timeout=30000"
+    "test:integration": "vitest run integration --test-timeout=60000"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
-import { sleep, until } from './lib.js';
+import { sleep, until, updateDotEnvString } from './lib.js';
 
 type ServerPayload = {
   id: number;
@@ -308,16 +308,9 @@ export class Site {
     );
   }
 
-  async setEnvironmentVariables(variables: Record<string, string>) {
-    let env = await Forge.getEnvironmentFile(this.server_id, this.id);
-    Object.entries(variables).map(([key, value]) => {
-      if (new RegExp(`${key}=`).test(env)) {
-        env = env.replace(new RegExp(`${key}=.*`), `${key}=${value}`);
-      } else {
-        env += `\n${key}=${value}\n`;
-      }
-    });
-    await Forge.updateEnvironmentFile(this.server_id, this.id, env);
+  async setEnvironmentVariables(variables: Record<string, string | undefined>) {
+    const env = await Forge.getEnvironmentFile(this.server_id, this.id);
+    await Forge.updateEnvironmentFile(this.server_id, this.id, updateDotEnvString(env, variables));
   }
 
   async installScheduler() {

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -34,6 +34,13 @@ type DatabasePayload = {
   name: string;
 };
 
+type CommandPayload = {
+  id: number;
+  command: string;
+  status: string;
+  duration: string;
+};
+
 export class ForgeError extends Error {
   axiosError: AxiosError;
   data?: unknown;
@@ -192,6 +199,17 @@ export class Forge {
 
   static async activateCertificate(server: number, site: number, certificate: number) {
     await this.post(`servers/${server}/sites/${site}/certificates/${certificate}/activate`);
+  }
+
+  static async runCommand(server: number, site: number, command: string) {
+    return (await this.post<{ command: CommandPayload }>(`servers/${server}/sites/${site}/commands`, { command })).data
+      .command;
+  }
+
+  static async getCommand(server: number, site: number, command: number) {
+    return (
+      await this.get<{ command: CommandPayload; output: string }>(`servers/${server}/sites/${site}/commands/${command}`)
+    ).data;
   }
 
   static token(token: string) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -30,6 +30,17 @@ export function normalizeDomainName(input: string) {
   return input.replace(/\W+/g, '-').substring(0, 63).replace(/^-|-$/g, '');
 }
 
+export function updateDotEnvString(env: string, variables: Record<string, string | undefined>) {
+  Object.entries(variables).map(([key, value]) => {
+    if (new RegExp(`${key}=`).test(env)) {
+      env = env.replace(new RegExp(`${key}=.*\n?`), value === undefined ? '' : `${key}=${value}\n`);
+    } else {
+      env += `\n${key}=${value}\n`;
+    }
+  });
+  return env;
+}
+
 // function serverWithFewestSites(servers: Server[], sites: Site[]): Server {
 //   const serverSites = sites.reduce((carry: { [_: string]: number }, site: Site) => {
 //     carry[site.server_id] ??= 0;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -20,11 +20,14 @@ export function tap<T>(value: any, interceptor: (v: any) => T) {
 }
 
 export function normalizeDatabaseName(input: string) {
-  return input.replace(/[^\w]+/g, '_').replace(/^_|_$/g, '');
+  return input
+    .replace(/[\W_]+/g, '_')
+    .substring(0, 64)
+    .replace(/^_|_$/g, '');
 }
 
 export function normalizeDomainName(input: string) {
-  return input.replace(/[^\w]+/g, '-').replace(/^-|-$/g, '');
+  return input.replace(/\W+/g, '-').substring(0, 63).replace(/^-|-$/g, '');
 }
 
 // function serverWithFewestSites(servers: Server[], sites: Site[]): Server {

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ export async function run() {
       await destroyPreview({
         branch: pr.pull_request.head.ref,
         servers,
+        environment,
       });
     }
   } catch (error) {

--- a/tests/unit/lib.test.ts
+++ b/tests/unit/lib.test.ts
@@ -58,6 +58,7 @@ describe('normalizeDatabaseName', () => {
     ['one! two? three 0x995', 'one_two_three_0x995'],
     ['jbk/px-454', 'jbk_px_454'],
     ["please+don't %20 do / this", 'please_don_t_20_do_this'],
+    ['a'.repeat(65), 'a'.repeat(64)],
   ])('%s → %s', (input, output) => {
     expect(normalizeDatabaseName(input)).toBe(output);
   });
@@ -72,6 +73,7 @@ describe('normalizeDomainName', () => {
     ['one! two? three 0x995', 'one-two-three-0x995'],
     ['jbk/px-454', 'jbk-px-454'],
     ["please+don't %20 do / this", 'please-don-t-20-do-this'],
+    ['a'.repeat(65), 'a'.repeat(63)],
   ])('%s → %s', (input, output) => {
     expect(normalizeDomainName(input)).toBe(output);
   });


### PR DESCRIPTION
This PR adds support for using a SQLite database for preview sites instead of Forge-installed MySQL/MariaDB/Postgres.

Adding `DB_CONNECTION=sqlite` to the `environment` input will now make the action skip creating a database when creating a preview site, and configure the site to use the default SQLite connection details. The database file will be created automatically when migrations are run for the first time (during the first deployment).

I think this is a decent workaround for sites that don't need a database at all for now too. All Forge servers have SQLite installed so this will always work, but more importantly they all default to including `artisan migrate --force` in the deployment script, so completely bypassing all database setup is more complicated than just not creating one initially. If a preview site really doesn't need a database to exist at all, the easiest and fastest option is to set it up to use SQLite.

Closes #28.