### PR TITLE
Add action outputs for site id and url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,11 @@ inputs:
   clone-certificate:
     description: Forge SSL certificate ID to clone to the preview site.
     required: false
+outputs:
+  site-url:
+    description: 'The URL of the site that was deployed.'
+  site-id:
+    description: 'The Forge ID of the site that was created.'
 runs:
   using: node20
   main: dist/index.js

--- a/src/action.ts
+++ b/src/action.ts
@@ -87,7 +87,7 @@ export async function createPreview({
   core.info('Waiting for SSL certificate to be activated.');
   await site.ensureCertificateActivated();
 
-  return { url: `https://${site.name}` };
+  return { url: `https://${site.name}`, id: site.id };
 }
 
 export async function destroyPreview({

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,9 @@ export async function run() {
       });
 
       if (preview) {
+        core.setOutput('site-url', preview.url);
+        core.setOutput('site-id', preview.id);
+
         const octokit = github.getOctokit(githubToken);
         octokit.rest.issues.createComment({
           owner: pr.repository.owner.login,


### PR DESCRIPTION
This PR adds support for github action outputs.

I think this is a decent workaround for sites that have more complex requirements to make use of other github actions in a workflow / pipeline.

Closes #31 