### PR TITLE
Ensure Site is deleted

### DIFF
--- a/src/forge.ts
+++ b/src/forge.ts
@@ -400,6 +400,13 @@ export class Site {
 
   async delete() {
     await Forge.deleteSite(this.server_id, this.id);
+    await until(
+      () => this.status !== 'removing',
+      async () =>
+        this.refetch().catch((err) => {
+          this.status = null;
+        }),
+    );
   }
 
   async refetch() {


### PR DESCRIPTION
closes #35 
### Summary

Currently when deleting preview on pr close, sometimes the site is not fully deleted and on forge level it's no longer showing up under server sites, but on top nav it's still showing up and not fully deleted, which if pr is closed and reopened again will throws site already error and it won't be possible to preview deployments again.

I haven't properly tested same behavior with database, It may be possible that is reproduced 

In order to ensure site is fully deleted I Added a condition that refetch the site until it throws 404 where the error is caught and the status is set to null, otherwise the site status is on removing so it'll just wait until it's fully removed.

### Steps to reproduce the issue
- Create a site in forge and trigger destroy previes in debug.ts notice that the site is partially deleted and still accessible through id from url and from top nav menu **sites**
- Repeat the same process with the code in this pr, the site will be fully deleted
