### PR TITLE
Add `no-certificate` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   clone-certificate:
     description: Forge SSL certificate ID to clone to the preview site.
     required: false
+  no-certificate:
+    description: Skip the creation of a certificate and serve the preview site over HTTP instead of HTTPS.
+    required: false
 outputs:
   site-url:
     description: 'The URL of the deployed preview site.'

--- a/src/action.ts
+++ b/src/action.ts
@@ -93,7 +93,7 @@ export async function createPreview({
     await site.ensureCertificateActivated();
   }
 
-  return { url: `https://${site.name}`, id: site.id };
+  return { url: `http${certificate === false ? '' : 's'}://${site.name}`, id: site.id };
 }
 
 export async function destroyPreview({


### PR DESCRIPTION
Adds a `no-certificate` input option to skip requesting a Let's Encrypt certificate and serve preview sites over HTTP.