### PR TITLE
Add ability to create deployment webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ Example:
     clone-certificate: 90051
 ```
 
+#### `deployment-webhooks`
+
+The `deployment-webhooks` input parameter allows you to add webhook URLs that Forge will notify of all deployments.
+
+Example:
+
+```yaml
+- uses: bakerkretzmar/laravel-deploy-preview@v2
+  with:
+    forge-token: ${{ secrets.FORGE_TOKEN }}
+    servers: |
+      qa-1.acme.dev 60041
+    deployment-webhooks: |
+      https://webhooks.example.com/1
+      https://webhooks.example.com/2
+```
+
 ### Databases
 
 This action creates a new database for each preview site and deletes the database when the preview site is deleted. If your Forge server has one of the default supported database engines installed (MySQL, MariaDB, or PostgreSQL), that database engine will be used and no additional configuration is necessary.

--- a/action.yml
+++ b/action.yml
@@ -31,14 +31,17 @@ inputs:
     description: Skip the creation of a certificate and serve the preview site over HTTP instead of HTTPS.
     required: false
     default: false
+  deployment-webhooks:
+    description: URLs to send webhooks to after Forge deployments. Enter multiple URLs on separate lines.
+    required: false
 outputs:
   site-url:
-    description: 'The URL of the deployed preview site.'
+    description: The URL of the deployed preview site.
   site-id:
-    description: 'The Forge ID of the deployed preview site.'
+    description: The Forge ID of the deployed preview site.
 runs:
   using: node20
   main: dist/index.js
 branding:
-  icon: 'eye'
-  color: 'red'
+  icon: eye
+  color: red

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,6 +10,7 @@ export async function createPreview({
   environment = {},
   certificate,
   name,
+  webhooks,
 }: {
   branch: string;
   repository: string;
@@ -18,6 +19,7 @@ export async function createPreview({
   environment?: Record<string, string>;
   certificate?: { type: 'clone'; certificate: number } | { type: 'existing'; certificate: string; key: string } | false;
   name?: string;
+  webhooks: string[];
 }) {
   core.info(`Creating preview site for branch: ${branch}.`);
 
@@ -84,6 +86,9 @@ export async function createPreview({
 
   core.info('Enabling Quick Deploy.');
   await site.enableQuickDeploy();
+
+  core.info('Setting up webhooks.');
+  await Promise.all(webhooks.map((url) => site.createWebhook(url)));
 
   core.info('Deploying site.');
   await site.deploy();

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -41,6 +41,11 @@ type CommandPayload = {
   duration: string;
 };
 
+type WebhookPayload = {
+  id: number;
+  url: string;
+};
+
 export class ForgeError extends Error {
   axiosError: AxiosError;
   data?: unknown;
@@ -210,6 +215,11 @@ export class Forge {
     return (
       await this.get<{ command: CommandPayload; output: string }>(`servers/${server}/sites/${site}/commands/${command}`)
     ).data;
+  }
+
+  static async createWebhook(server: number, site: number, url: string) {
+    return (await this.post<{ webhook: WebhookPayload }>(`servers/${server}/sites/${site}/webhooks`, { url })).data
+      .webhook;
   }
 
   static token(token: string) {
@@ -394,6 +404,10 @@ export class Site {
       () => this.deployment_status === null,
       async () => await this.refetch(),
     );
+  }
+
+  async createWebhook(url: string) {
+    await Forge.createWebhook(this.server_id, this.id, url);
   }
 
   // TODO figure out a way to safely+reliably figure the name out internally so it doesn't need to be passed in

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ export async function run() {
     const cloneCertificate = core.getInput('clone-certificate', { required: false });
     const noCertificate = core.getBooleanInput('no-certificate', { required: false });
 
+    const webhooks = core.getMultilineInput('deployment-webhooks', { required: false });
     let certificate:
       | { type: 'clone'; certificate: number }
       | { type: 'existing'; certificate: string; key: string }
@@ -99,6 +100,7 @@ export async function run() {
         afterDeploy,
         environment,
         certificate,
+        webhooks,
       });
 
       if (preview) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ export async function run() {
     const noCertificate = core.getBooleanInput('no-certificate', { required: false });
 
     const webhooks = core.getMultilineInput('deployment-webhooks', { required: false });
+
     let certificate:
       | { type: 'clone'; certificate: number }
       | { type: 'existing'; certificate: string; key: string }


### PR DESCRIPTION
Adds support for webhooks.

There doesn't seem to be any way to get or set deployment failure notification emails, or to set the Slack channel and Teams/Discord URLs, via the Forge API, but I emailed them to ask about it.

See #42.