### PR TITLE
Omit username if it's an empty string

### DIFF
--- a/src/forge.ts
+++ b/src/forge.ts
@@ -102,7 +102,7 @@ export class Forge {
         aliases,
         directory: '/public',
         isolated,
-        username,
+        username: username || undefined,
         database,
         php_version: php || undefined,
       })


### PR DESCRIPTION
Same issue as #48. If no username is provided, we send Forge an empty string, which it accepts and uses as the site's username. Then it tries to create a site in that user's home directory, which doesn't exist, so that fails.

@DanielCoulbourne @GlitchWitch @noahc3 let me know if this gets you up and running normally again!

Fixes #50.